### PR TITLE
Allow Svelte loader options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ mix.js('resources/js/app.js', 'public/js')
     .svelte();
 ```
 
+Enable dev mode example:
+
+``` js
+const mix = require('laravel-mix');
+
+require('laravel-mix-svelte');
+
+mix.js('resources/js/app.js', 'public/js')
+    .sass('resources/sass/app.scss', 'public/css')
+    .svelte({
+        dev: true
+    });
+```
+
 ### Future planned improvements
 
 - [ ] Add hotReload functionality

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mix.js('resources/js/app.js', 'public/js')
     .svelte();
 ```
 
-Enable dev mode example:
+Use the options parameter example:
 
 ``` js
 const mix = require('laravel-mix');
@@ -45,6 +45,9 @@ mix.js('resources/js/app.js', 'public/js')
         dev: true
     });
 ```
+
+For more options see the svelte-loader package:
+[Svelte Loader](https://github.com/sveltejs/svelte-loader)
 
 ### Future planned improvements
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,33 @@
-let mix = require('laravel-mix');
+let mix = require("laravel-mix");
 
 class Svelte {
-  dependencies() {
-      this.requiresReload = true;
-      return ['svelte', 'svelte-loader'];
-  }
-  
-  webpackRules () {
-      return {
-          test: /\.(html|svelte)$/,
-          use: 'svelte-loader',
-      }
-  }
-  
-  boot() {
-      let svelte = require('svelte');
-      let loader = require('svelte-loader');
-  }
+	constructor() {
+		this.options = {};
+	}
+
+	dependencies() {
+		this.requiresReload = true;
+		return ["svelte", "svelte-loader"];
+	}
+
+	register(options) {
+		this.options = { ...this.options, ...options };
+	}
+
+	webpackRules() {
+		return {
+			test: /\.(html|svelte)$/,
+			use: {
+				loader: "svelte-loader",
+				options: this.options
+			}
+		};
+	}
+
+	boot() {
+		let svelte = require("svelte");
+		let loader = require("svelte-loader");
+	}
 }
 
-mix.extend('svelte', new Svelte());
+mix.extend("svelte", new Svelte());


### PR DESCRIPTION
Allow the implementation to set options for the Svelte loader. This is very useful to enable dev mode for example.