### PR TITLE
Add webpack config from svelte webpack template

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,20 @@ class Svelte {
 		};
 	}
 
+    webpackConfig(webpackConfig) {
+        webpackConfig.resolve.mainFields = [
+            'svelte',
+            'browser',
+            'module',
+            'main',
+        ];
+        webpackConfig.resolve.extensions = ['.mjs', '.js', '.svelte'];
+        webpackConfig.resolve.alias.svelte = path.resolve(
+            'node_modules',
+            'svelte'
+        );
+    }
+
 	boot() {
 		let svelte = require("svelte");
 		let loader = require("svelte-loader");


### PR DESCRIPTION
This commit takes configuration found in the official svelte webpack template and includes it in this extension. The configuration is specific to svelte development and appears to reduce bugs introduced from including thirds party svelte libraries.

Aims to fix issue #5 .