### PR TITLE
Mix 6 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 let mix = require("laravel-mix");
+let path = require("path");
 
 class Svelte {
 	constructor() {
@@ -38,6 +39,8 @@ class Svelte {
             'main',
         ];
         webpackConfig.resolve.extensions = ['.mjs', '.js', '.svelte'];
+
+        webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
         webpackConfig.resolve.alias.svelte = path.resolve(
             'node_modules',
             'svelte'

--- a/src/index.js
+++ b/src/index.js
@@ -19,13 +19,13 @@ class Svelte {
             {
                 test: /\.(html|svelte)$/,
                 use: [
-                    { loader: 'babel-loader', options: mix.config.babel() },
+                    { loader: 'babel-loader', options: Config.babel() },
                     { loader: 'svelte-loader', options: this.options }
                 ]
             },
             {
                 test: /\.(mjs)$/,
-                use: { loader: 'babel-loader', options: mix.config.babel() }
+                use: { loader: 'babel-loader', options: Config.babel() }
             }
         ];
     }


### PR DESCRIPTION
I was running into the same issues described in https://github.com/wewowweb/laravel-mix-svelte/issues/11#issuecomment-762116535 and was able to resolve them by replacing `mix.config.babel()` with the Laravel Mix 6.0 convention of `Config.babel()`. I also encountered two other errors. The first was as follows: 

```bash
[webpack-cli] ReferenceError: path is not defined
    at Svelte.webpackConfig (/project/node_modules/laravel-mix-svelte/src/index.js:41:46)
```
(Line reference: https://github.com/wewowweb/laravel-mix-svelte/blob/master/src/index.js#L41)

When I added path as a dependency, I got this error:

```bash
[webpack-cli] TypeError: Cannot set property 'svelte' of undefined
    at Svelte.webpackConfig (/project/node_modules/laravel-mix-svelte/src/index.js:44:44)
```

(Line reference: https://github.com/wewowweb/laravel-mix-svelte/blob/master/src/index.js#L41)

I used [this pattern](https://github.com/JeffreyWay/laravel-mix/blob/master/src/components/Vue.js#L87) from the Laravel Mix core Vue extension to ensure that `webpackConfig.resolve.alias` is defined.

This PR includes all three fixes and appears to work for me. I'm using:

Node: v12.16.3
NPM: 6.14.10
Laravel Mix: 6.0.9