### PR TITLE
Enabling new filetypes to match svelte-loader rules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ let path = require("path");
 class Svelte {
 	constructor() {
 		this.options = {};
+		this.extensions = [];
+		this.ruleExtensions = "";
 	}
 
 	dependencies() {
@@ -11,14 +13,19 @@ class Svelte {
 		return ["svelte", "svelte-loader"];
 	}
 
-	register(options) {
+	register(options, extensions = []) {
 		this.options = { ...this.options, ...options };
+		this.extensions = [ '.mjs', '.js', '.svelte', ...extensions];
+		let extensionRules = extensions.map(function(item) {
+			return item.startsWith('.') ? item.substring(1) : item;
+		});
+		this.ruleExtensions = [ "html|svelte", ...extensionRules ].join('|');
 	}
 
     webpackRules() {
         return [
             {
-                test: /\.(html|svelte)$/,
+                test: new RegExp('\.('+ this.ruleExtensions + ')$'),
                 use: [
                     { loader: 'babel-loader', options: Config.babel() },
                     { loader: 'svelte-loader', options: this.options }
@@ -38,7 +45,7 @@ class Svelte {
             'module',
             'main',
         ];
-        webpackConfig.resolve.extensions = ['.mjs', '.js', '.svelte'];
+        webpackConfig.resolve.extensions = this.extensions;
 
         webpackConfig.resolve.alias = webpackConfig.resolve.alias || {};
         webpackConfig.resolve.alias.svelte = path.resolve(


### PR DESCRIPTION
I have been wanting to add support for Markdown to some applications that I have running Laravel + Svelte and really appreciate the work put in to making this mix extension. However, there's some limitations that don't allow for extra plugins that use custom file extensions like `mdsvex` (https://mdsvex.com/). This commit allows some extra configuration to be passed through to webpack, to enable different file extensions to be managed by svelte-loader. People not using this extra functionality don't need to make any changes to their existing config.

An example for usage using mdsvex:
```
const mix = require('laravel-mix');
require('laravel-mix-svelte');
const { mdsvex } = require('mdsvex');

mix.svelte({
  preprocess: mdsvex({
      extensions: [".svx", ".md"]
    })
}, ['.svx', '.md'])
```
This can be simplified or expanded depending on usage, but the change would allow the end user to decide what extensions get passed to `svelte-loader`.