### PR TITLE
Update dev compiler option...

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ require('laravel-mix-svelte');
 mix.js('resources/js/app.js', 'public/js')
     .sass('resources/sass/app.scss', 'public/css')
     .svelte({
-        dev: true
+        compilerOptions: {
+            dev: true,
+        },
     });
 ```
 


### PR DESCRIPTION
I just installed this and couldn't get dev mode on in order to use the Svelte extension in Chrome. I was using the `{dev: true}` option, but it wouldn't go. Once I changed it to 
```
compilerOptions: {
    dev: true,
},
``` 
per the svelte-loader docs, it worked. Maybe I'm missing something, but I thought I'd just share this here.